### PR TITLE
Add a route to the internet gateway.

### DIFF
--- a/networking/README.md
+++ b/networking/README.md
@@ -46,6 +46,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_compute_route.egress-inet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_route) | resource |
 | [google_compute_subnetwork.regional](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
 | [google_dns_managed_zone.cloud-run-internal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
 | [google_dns_managed_zone.private-google-apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -7,6 +7,15 @@ resource "google_compute_network" "this" {
   delete_default_routes_on_create = true
 }
 
+// Create a default route to the Internet.
+resource "google_compute_route" "egress-inet" {
+  name    = var.name
+  network = google_compute_network.this.name
+
+  dest_range       = "0.0.0.0/0"
+  next_hop_gateway = "default-internet-gateway"
+}
+
 // Create regional subnets in each of the specified regions,
 // which we will use to operate Cloud Run services.
 resource "google_compute_subnetwork" "regional" {


### PR DESCRIPTION
This appears to be necessary to access Google services even with the bit set on the subnets.