### PR TITLE
Use the multi-variable `for` when walking a `map` type.

### DIFF
--- a/cloudevent-recorder/README.md
+++ b/cloudevent-recorder/README.md
@@ -36,10 +36,10 @@ module "foo-emits-events" {
 
   retention-period = 30 // keep around 30 days worth of event data
 
-   types = {
-     "com.example.foo": file("${path.module}/foo.schema.json"),
-     "com.example.bar": file("${path.module}/bar.schema.json"),
-   }
+  types = {
+    "com.example.foo": file("${path.module}/foo.schema.json"),
+    "com.example.bar": file("${path.module}/bar.schema.json"),
+  }
 }
 ```
 

--- a/cloudevent-recorder/recorder.tf
+++ b/cloudevent-recorder/recorder.tf
@@ -126,6 +126,6 @@ module "recorder-dashboard" {
   service_name = var.name
 
   triggers = {
-    for type in var.types : "type: ${type}" => "${var.name}-${random_id.trigger-suffix[type].hex}"
+    for type, schema in var.types : "type: ${type}" => "${var.name}-${random_id.trigger-suffix[type].hex}"
   }
 }


### PR DESCRIPTION
The previous "fix" was still broken, but this cleanly applies with my local example changed to use the recorder.