### PR TITLE
cleanup: detect project ID instead of passing via env

### DIFF
--- a/cloudevent-broker/cmd/ingress/main.go
+++ b/cloudevent-broker/cmd/ingress/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -44,11 +43,7 @@ func main() {
 		log.Fatalf("failed to create CE client, %v", err)
 	}
 
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Fatalf("failed to get project ID, %v", err)
-	}
-	psc, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(google.ComputeTokenSource("")))
+	psc, err := pubsub.NewClient(ctx, pubsub.DetectProjectID, option.WithTokenSource(google.ComputeTokenSource("")))
 	if err != nil {
 		log.Fatalf("failed to create pubsub client, %v", err)
 	}

--- a/cloudevent-broker/cmd/ingress/main.go
+++ b/cloudevent-broker/cmd/ingress/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -26,9 +27,8 @@ const (
 )
 
 type envConfig struct {
-	Port    int    `envconfig:"PORT" default:"8080" required:"true"`
-	Project string `envconfig:"PROJECT_ID" required:"true"`
-	Topic   string `envconfig:"PUBSUB_TOPIC" required:"true"`
+	Port  int    `envconfig:"PORT" default:"8080" required:"true"`
+	Topic string `envconfig:"PUBSUB_TOPIC" required:"true"`
 }
 
 func main() {
@@ -44,7 +44,11 @@ func main() {
 		log.Fatalf("failed to create CE client, %v", err)
 	}
 
-	psc, err := pubsub.NewClient(ctx, env.Project, option.WithTokenSource(google.ComputeTokenSource("")))
+	projectID, err := metadata.ProjectID()
+	if err != nil {
+		log.Fatalf("failed to get project ID, %v", err)
+	}
+	psc, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(google.ComputeTokenSource("")))
 	if err != nil {
 		log.Fatalf("failed to create pubsub client, %v", err)
 	}

--- a/cloudevent-broker/ingress.tf
+++ b/cloudevent-broker/ingress.tf
@@ -70,10 +70,6 @@ resource "google_cloud_run_v2_service" "this" {
       image = cosign_sign.this.signed_ref
 
       env {
-        name  = "PROJECT_ID"
-        value = var.project_id
-      }
-      env {
         name  = "PUBSUB_TOPIC"
         value = google_pubsub_topic.this[each.key].name
       }
@@ -108,7 +104,7 @@ module "resources" {
 module "width" { source = "../dashboard/sections/width" }
 
 module "layout" {
-  source   = "../dashboard/sections/layout"
+  source = "../dashboard/sections/layout"
   sections = [
     module.topic.section,
     module.logs.section,


### PR DESCRIPTION
Cloud Run services know what project they're running in, let's just use that.