### PR TITLE
support passing alert IDs to service dashboards

### DIFF
--- a/dashboard/sections/alerts/main.tf
+++ b/dashboard/sections/alerts/main.tf
@@ -1,0 +1,34 @@
+variable "title" { type = string }
+variable "collapsed" { default = false }
+variable "alert" { type = string }
+
+module "width" { source = "../width" }
+
+module "alert" {
+  source     = "../../widgets/alert"
+  title      = "Alert"
+  alert_name = var.alert
+}
+
+locals {
+  tiles = [{
+    yPos   = 0
+    xPos   = 0
+    height = 3
+    width  = module.width.size
+    widget = module.alert.widget
+  }]
+}
+
+module "collapsible" {
+  source = "../collapsible"
+
+  // If no alert is defined, this is an empty collapsed section.
+  title     = var.title
+  tiles     = var.alert == "" ? [] : local.tiles
+  collapsed = var.collapsed || var.alert == ""
+}
+
+output "section" {
+  value = module.collapsible.section
+}

--- a/dashboard/sections/collapsible/main.tf
+++ b/dashboard/sections/collapsible/main.tf
@@ -12,7 +12,7 @@ output "section" {
   value = concat([{
     yPos   = local.start_row
     xPos   = 0,
-    height = max([for s in var.tiles : s.yPos + s.height - local.start_row]...),
+    height = length(var.tiles) == 0 ? 0 : max([for s in var.tiles : s.yPos + s.height - local.start_row]...),
     width  = module.width.size,
     widget = {
       title = var.title

--- a/dashboard/sections/collapsible/main.tf
+++ b/dashboard/sections/collapsible/main.tf
@@ -3,7 +3,7 @@ variable "tiles" {}
 variable "collapsed" { default = false }
 
 locals {
-  start_row = min([for s in var.tiles : s.yPos]...)
+  start_row = length(var.tiles) == 0 ? 0 : min([for s in var.tiles : s.yPos]...)
 }
 
 module "width" { source = "../width" }

--- a/dashboard/service/README.md
+++ b/dashboard/service/README.md
@@ -52,6 +52,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_alerts"></a> [alerts](#module\_alerts) | ../sections/alerts | n/a |
 | <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | ../sections/logs | n/a |
@@ -68,6 +69,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alert"></a> [alert](#input\_alert) | Alerting policies to add to the dashboard. | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 

--- a/dashboard/service/dashboard.tf
+++ b/dashboard/service/dashboard.tf
@@ -16,15 +16,24 @@ module "resources" {
   filter = ["resource.type=\"cloud_run_revision\""]
 }
 
+module "alerts" {
+  source = "../sections/alerts"
+  alert  = var.alert
+  title  = "Alert"
+}
+
 module "width" { source = "../sections/width" }
 
 module "layout" {
-  source   = "../sections/layout"
-  sections = [
-    module.logs.section,
-    module.http.section,
-    module.resources.section,
-  ]
+  source = "../sections/layout"
+  sections = concat(
+    var.alert == "" ? [] : [module.alerts.section],
+    [
+      module.logs.section,
+      module.http.section,
+      module.resources.section,
+    ]
+  )
 }
 
 resource "google_monitoring_dashboard" "dashboard" {

--- a/dashboard/service/variables.tf
+++ b/dashboard/service/variables.tf
@@ -7,3 +7,10 @@ variable "labels" {
   description = "Additional labels to apply to the dashboard."
   default     = {}
 }
+
+variable "alert" {
+  description = "Alerting policies to add to the dashboard."
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
This should produce full-width alert chart widgets for each alert. I might need to iterate on this with changes in tf-prober to see this all working together. It at least doesn't regress for non-alert-having services.