### PR TITLE
Add outbound HTTP dashboard

### DIFF
--- a/dashboard/sections/http/main.tf
+++ b/dashboard/sections/http/main.tf
@@ -27,14 +27,6 @@ locals {
   gmp_filter = [for f in var.filter : f if !strcontains(f, "resource.type")]
 }
 
-output "gmp_filter" {
-  value = local.gmp_filter
-}
-
-output "var_filter" {
-  value = var.filter
-}
-
 // TODO(mattmoor): output HTTP charts.
 module "outbound_request_count" {
   source = "../../widgets/xy"

--- a/dashboard/service/dashboard.tf
+++ b/dashboard/service/dashboard.tf
@@ -5,9 +5,10 @@ module "logs" {
 }
 
 module "http" {
-  source = "../sections/http"
-  title  = "HTTP"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source       = "../sections/http"
+  title        = "HTTP"
+  filter       = ["resource.type=\"cloud_run_revision\""]
+  service_name = var.service_name
 }
 
 module "resources" {


### PR DESCRIPTION
This based on the metrics we export in our metricking transport.

There are some difference with Cloud Run native metrics:
1. we can't add `resource.type` to our metrics. I work around by not using `resource.type` in the filter here.
2. the cloud run native metrics has `service_name` being a `resource.label`, which AFAIK we can't add to our Prometheus metrics. when following the instruction [here](https://cloud.google.com/run/docs/tutorials/custom-metrics-opentelemetry-sidecar) the `service_name` is a `metric.label`. As a result, we will need to add that filter here, unlike the other widgets that can inherit from the Dashboard's. 

For 2. we could also add a template variable at the Dashboard level that use a `metric.label`, but will look a bit confusing as we have two drop downs that look exactly the same. Since we are baking `var.service_name` to the dashboard name anyway, I think we may as well drop the template filter from there.

This is how this change would look like (if the metrics are there)

![image](https://github.com/chainguard-dev/terraform-cloudrun-glue/assets/138266/a14961b7-cf69-4055-8601-0a87e4d31309)
