### PR TITLE
Add gRPC (inbound)

### DIFF
--- a/dashboard/sections/grpc/grpc.tf
+++ b/dashboard/sections/grpc/grpc.tf
@@ -1,0 +1,105 @@
+variable "title" { type = string }
+variable "filter" { type = list(string) }
+variable "collapsed" { default = false }
+variable "grpc_service_name" { type = string }
+
+module "width" { source = "../width" }
+
+module "request_count" {
+  source = "../../widgets/xy"
+  title  = "Request count"
+  filter = concat(var.filter, [
+    "metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\"",
+    "metric.label.grpc_service=monitoring.regex.full_match(\"${var.grpc_service_name}.*\")",
+  ])
+  group_by_fields = [
+    "metric.label.\"grpc_service\"",
+    "metric.label.\"grpc_method\"",
+    "metric.label.\"grpc_code\""
+  ]
+  primary_align    = "ALIGN_RATE"
+  primary_reduce   = "REDUCE_NONE"
+  secondary_align  = "ALIGN_NONE"
+  secondary_reduce = "REDUCE_SUM"
+}
+
+module "incoming_latency" {
+  source = "../../widgets/latency"
+  title  = "Incoming request latency"
+  filter = concat(var.filter, [
+    "metric.type=\"prometheus.googleapis.com/grpc_server_handling_seconds/histogram\"",
+    "metric.label.\"grpc_service\"=monitoring.regex.full_match(\"${var.grpc_service_name}.*\")",
+  ])
+  group_by_fields = [
+    "metric.label.\"grpc_service\"",
+    "metric.label.\"grpc_method\"",
+  ]
+}
+
+module "outbound_request_count" {
+  source = "../../widgets/xy"
+  title  = "Request count"
+  filter = concat(var.filter, [
+    "metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\"",
+    "metric.label.grpc_service=monitoring.regex.full_match(\"${var.grpc_service_name}.*\")",
+  ])
+  group_by_fields = [
+    "metric.label.\"grpc_service\"",
+    "metric.label.\"grpc_method\"",
+    "metric.label.\"grpc_code\""
+  ]
+  primary_align    = "ALIGN_RATE"
+  primary_reduce   = "REDUCE_NONE"
+  secondary_align  = "ALIGN_NONE"
+  secondary_reduce = "REDUCE_SUM"
+}
+
+module "outbound_latency" {
+  source = "../../widgets/latency"
+  title  = "Incoming request latency"
+  filter = concat(var.filter, [
+    "metric.type=\"prometheus.googleapis.com/grpc_server_handling_seconds/histogram\"",
+    "metric.label.\"grpc_service\"=monitoring.regex.full_match(\"chainguard.datastore.*\")",
+  ])
+  group_by_fields = [
+    "metric.label.\"grpc_service\"",
+    "metric.label.\"grpc_method\"",
+  ]
+}
+
+locals {
+  columns = 2
+  unit    = module.width.size / local.columns
+
+  // https://www.terraform.io/language/functions/range
+  // N columns, unit width each  ([0, unit, 2 * unit, ...])
+  col = range(0, local.columns * local.unit, local.unit)
+
+  tiles = [
+    {
+      yPos   = 0
+      xPos   = local.col[0],
+      height = local.unit,
+      width  = local.unit,
+      widget = module.request_count.widget,
+      }, {
+      yPos   = 0
+      xPos   = local.col[1],
+      height = local.unit,
+      width  = local.unit,
+      widget = module.incoming_latency.widget,
+    },
+  ]
+}
+
+module "collapsible" {
+  source = "../collapsible"
+
+  title     = var.title
+  tiles     = local.tiles
+  collapsed = var.collapsed
+}
+
+output "section" {
+  value = module.collapsible.section
+}

--- a/dashboard/service/README.md
+++ b/dashboard/service/README.md
@@ -53,6 +53,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alerts"></a> [alerts](#module\_alerts) | ../sections/alerts | n/a |
+| <a name="module_grpc"></a> [grpc](#module\_grpc) | ../sections/grpc | n/a |
 | <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | ../sections/logs | n/a |
@@ -70,6 +71,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alerts"></a> [alerts](#input\_alerts) | Alerting policies to add to the dashboard. | `list(string)` | `[]` | no |
+| <a name="input_grpc_service_name"></a> [grpc\_service\_name](#input\_grpc\_service\_name) | Name of the GRPC service(s) to monitor | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 

--- a/dashboard/service/dashboard.tf
+++ b/dashboard/service/dashboard.tf
@@ -11,6 +11,13 @@ module "http" {
   service_name = var.service_name
 }
 
+module "grpc" {
+  source            = "../sections/grpc"
+  title             = "GRPC"
+  filter            = []
+  grpc_service_name = var.grpc_service_name
+}
+
 module "resources" {
   source = "../sections/resources"
   title  = "Resources"
@@ -34,6 +41,7 @@ module "layout" {
     [
       module.logs.section,
       module.http.section,
+      module.grpc.section,
       module.resources.section,
     ]
   )

--- a/dashboard/service/variables.tf
+++ b/dashboard/service/variables.tf
@@ -14,3 +14,11 @@ variable "alerts" {
   default     = []
 }
 
+# Currently our metrics does not have service_name label: we
+# are working around by specifying the grpc_service name label
+# instead while we fix the metric labeling.
+variable "grpc_service_name" {
+  description = "Name of the GRPC service(s) to monitor"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Currently our gRPC metrics dp not have the right label `service_name` yet. That means we can't have outbound gRPC widgets (which would need to distinguish by caller i.e. `service_name`).

I'm using the `grpc_service_name` variable as a work around here. Will remove it and add outbound gRPC when the metric label is fixed.