### PR TITLE
otel-collector config to populate FAAS name

### DIFF
--- a/otel-collector/cmd/otel-collector/kodata/config.yaml
+++ b/otel-collector/cmd/otel-collector/kodata/config.yaml
@@ -7,6 +7,8 @@ receivers:
         static_configs:
         # TODO: make this configurable
         - targets: ["localhost:2112"]
+        # Do not relabel job and instance labels if existed.
+        honor_labels: true
         metric_relabel_configs:
           - source_labels: [ __name__ ]
             regex: '^prometheus_.*'
@@ -39,17 +41,22 @@ processors:
 
   resource:
     attributes:
-      # add instance_id as a resource attribute
-    - key: service.instance.id
-      from_attribute: faas.id
+    # The `gcp` resourcedetection processor sets `faas.name` to the name of the
+    # Cloud Run service or the Cloud Run job.
+    - from_attribute: faas.name
+      # The googlemanagedprometheus exporter consumes `service.name` attribute
+      # and set the `job` resource label to this value. (See
+      # https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/764)
+      key: "service.name"
       action: upsert
-      # parse service name from K_SERVICE Cloud Run variable
-    - key: service.name
-      value: ${env:K_SERVICE}
-      action: insert
 
 exporters:
   googlemanagedprometheus:
+    sending_queue:
+      enabled: true
+      # we are handling metrics for a single pod, no need to have
+      # too many senders. this will also avoid out-of-order data.
+      num_consumers: 1
 
 extensions:
   health_check:


### PR DESCRIPTION
The `gcp` resource detection plugin populates the attribute `faas.name` to Cloud Run Service/Job, and Cloud Function name, which makes it a nice way to standardize on naming ([see](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md)). Using env var is less convenient for this purpose because Cloud Run Service name is `$K_SERVICE` and for Cloud Run Job it's `$CLOUD_RUN_JOB`.

The googlemanagedprometheus exporter consumes `service.name` attribute and create a resource label named `job` with this value when uploading metrics. There is no customization of this. ([see](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/764)).

This PR plumbs `faas.name` into `service.name` so we can get a resource label with the Cloud Run Service or Job name on all our exported metrics. Also dropping `instance id` because this is an unbounded dimension, and even worse when a lot of scaling-to-zero happens.